### PR TITLE
[휴면] - 휴면 유저의 인증번호를 관리하는 redis 추가 및 인증 번호가 일치하면 휴면 해제하는 기능 구현

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,17 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-aop</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.redisson</groupId>
+      <artifactId>redisson-spring-boot-starter</artifactId>
+      <version>3.16.7</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/nhnacademy/yes25/application/service/DormantService.java
+++ b/src/main/java/com/nhnacademy/yes25/application/service/DormantService.java
@@ -1,0 +1,11 @@
+package com.nhnacademy.yes25.application.service;
+
+import com.nhnacademy.yes25.presentation.dto.request.CreateAuthNumberRequest;
+import com.nhnacademy.yes25.presentation.dto.request.SubmitAuthNumberRequest;
+
+public interface DormantService {
+
+    void createAuthNumberByEmail(CreateAuthNumberRequest request);
+
+    Boolean updateUserStateByAuthNumber(SubmitAuthNumberRequest request);
+}

--- a/src/main/java/com/nhnacademy/yes25/application/service/dto/request/DoorayMessagePayload.java
+++ b/src/main/java/com/nhnacademy/yes25/application/service/dto/request/DoorayMessagePayload.java
@@ -1,0 +1,35 @@
+package com.nhnacademy.yes25.application.service.dto.request;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record DoorayMessagePayload(
+    String botName,
+    String botIconImage,
+    String text,
+    List<Attachment> attachments) {
+
+    public static DoorayMessagePayload from(String authNumber) {
+        return DoorayMessagePayload.builder()
+            .botName("인증 서버 Bot")
+            .botIconImage("https://www.tistory.com/favicon.ico")
+            .text("인증번호: " + authNumber)
+            .attachments(List.of(
+                Attachment.builder()
+                    .title("인증번호")
+                    .color("green")
+                    .text("인증번호: " + authNumber)
+                    .build()
+            ))
+            .build();
+    }
+
+    @Builder
+    public record Attachment(
+        String title,
+        String titleLink,
+        String color,
+        String text) {
+    }
+}

--- a/src/main/java/com/nhnacademy/yes25/application/service/dto/request/UnlockDormantRequest.java
+++ b/src/main/java/com/nhnacademy/yes25/application/service/dto/request/UnlockDormantRequest.java
@@ -1,0 +1,13 @@
+package com.nhnacademy.yes25.application.service.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record UnlockDormantRequest(String email) {
+
+    public static UnlockDormantRequest from(String email) {
+        return UnlockDormantRequest.builder()
+            .email(email)
+            .build();
+    }
+}

--- a/src/main/java/com/nhnacademy/yes25/application/service/impl/DormantServiceImpl.java
+++ b/src/main/java/com/nhnacademy/yes25/application/service/impl/DormantServiceImpl.java
@@ -1,0 +1,73 @@
+package com.nhnacademy.yes25.application.service.impl;
+
+import com.nhnacademy.yes25.application.service.DormantService;
+import com.nhnacademy.yes25.application.service.dto.request.DoorayMessagePayload;
+import com.nhnacademy.yes25.application.service.dto.request.UnlockDormantRequest;
+import com.nhnacademy.yes25.common.exception.ApplicationException;
+import com.nhnacademy.yes25.common.exception.payload.ErrorStatus;
+import com.nhnacademy.yes25.infrastructure.adaptor.DoorayAdaptor;
+import com.nhnacademy.yes25.infrastructure.adaptor.UserAdaptor;
+import com.nhnacademy.yes25.presentation.dto.request.CreateAuthNumberRequest;
+import com.nhnacademy.yes25.presentation.dto.request.SubmitAuthNumberRequest;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DormantServiceImpl implements DormantService {
+
+    private final DoorayAdaptor doorayAdaptor;
+    private final UserAdaptor userAdaptor;
+
+    private final RedissonClient redissonClient;
+    private final SecureRandom random;
+
+    @Override
+    public void createAuthNumberByEmail(CreateAuthNumberRequest request) {
+        String email = request.email();
+        String authNumber = generateAuthNumber();
+
+        RBucket<String> bucket = redissonClient.getBucket(email);
+        bucket.set(authNumber, 3, TimeUnit.MINUTES);
+
+        DoorayMessagePayload payload = DoorayMessagePayload.from(authNumber);
+
+        doorayAdaptor.sendAuthNumber(payload);
+    }
+
+    private boolean checkAuthNumberByRequest(SubmitAuthNumberRequest request) {
+        RBucket<String> bucket = redissonClient.getBucket(request.email());
+        String storedAuthNumber = bucket.get();
+
+        if (Objects.isNull(storedAuthNumber)) {
+            throw new ApplicationException(
+                ErrorStatus.toErrorStatus("인증번호가 만료되었습니다.", 401, LocalDateTime.now()));
+        }
+
+        return storedAuthNumber.equals(request.verificationCode());
+    }
+
+    @Override
+    public Boolean updateUserStateByAuthNumber(SubmitAuthNumberRequest request) {
+        boolean isEqualAuthNumber = checkAuthNumberByRequest(request);
+
+        if (isEqualAuthNumber) {
+            UnlockDormantRequest unlockDormantRequest = UnlockDormantRequest.from(request.email());
+            userAdaptor.unLockDormantState(unlockDormantRequest);
+        }
+
+        return isEqualAuthNumber;
+    }
+
+    private String generateAuthNumber() {
+        int number = random.nextInt(90000) + 10000;
+
+        return String.valueOf(number);
+    }
+}

--- a/src/main/java/com/nhnacademy/yes25/common/aop/GlobalControllerAdvice.java
+++ b/src/main/java/com/nhnacademy/yes25/common/aop/GlobalControllerAdvice.java
@@ -1,0 +1,41 @@
+package com.nhnacademy.yes25.common.aop;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalControllerAdvice {
+
+    private final ObjectMapper objectMapper;
+
+    @ExceptionHandler(FeignException.Forbidden.class)
+    public ResponseEntity<Map<String, Object>> handleFeignForbiddenException(FeignException.Forbidden ex) {
+        Map<String, Object> errorDetails = new HashMap<>();
+        try {
+            String jsonMessage = ex.contentUTF8();
+
+            Map<String, Object> parsedMessage = objectMapper.readValue(jsonMessage, HashMap.class);
+
+            errorDetails.put("message", parsedMessage.get("message"));
+            errorDetails.put("status", parsedMessage.get("status"));
+            errorDetails.put("timestamp", parsedMessage.get("timestamp"));
+        } catch (IOException e) {
+            errorDetails.put("message", "Error parsing FeignException message");
+            errorDetails.put("status", HttpStatus.INTERNAL_SERVER_ERROR.value());
+            errorDetails.put("timestamp", LocalDateTime.now());
+        }
+
+        return new ResponseEntity<>(errorDetails, HttpStatus.FORBIDDEN);
+    }
+}

--- a/src/main/java/com/nhnacademy/yes25/common/config/AppConfig.java
+++ b/src/main/java/com/nhnacademy/yes25/common/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.nhnacademy.yes25.common.config;
+
+import java.security.SecureRandom;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public SecureRandom secureRandom() {
+        return new SecureRandom();
+    }
+}

--- a/src/main/java/com/nhnacademy/yes25/common/config/RedisConfig.java
+++ b/src/main/java/com/nhnacademy/yes25/common/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.nhnacademy.yes25.common.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
+    @Value("${spring.data.redis.database}")
+    private int redisDatabase;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+            .setAddress("redis://" + redisHost + ":" + redisPort)
+            .setPassword(redisPassword)
+            .setDatabase(redisDatabase);
+
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/nhnacademy/yes25/common/config/SecurityConfig.java
+++ b/src/main/java/com/nhnacademy/yes25/common/config/SecurityConfig.java
@@ -19,12 +19,14 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
         http
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
-                .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authorizeRequests ->
-                        authorizeRequests
-                                .requestMatchers("/auth/login", "/users/**", "/auth/refresh", "/auth/login/none","/auth/info").permitAll()
-                                .anyRequest().authenticated());
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(authorizeRequests ->
+                authorizeRequests
+                    .requestMatchers("/auth/login", "/users/**", "/auth/refresh",
+                        "/auth/login/none", "/auth/info").permitAll()
+                    .requestMatchers("/auth/dormant/**").permitAll()
+                    .anyRequest().authenticated());
 
         return http.build();
     }

--- a/src/main/java/com/nhnacademy/yes25/common/jwt/JwtFilter.java
+++ b/src/main/java/com/nhnacademy/yes25/common/jwt/JwtFilter.java
@@ -106,7 +106,8 @@ public class JwtFilter extends GenericFilterBean {
      */
     private boolean isExcludedPath(String path) {
 
-        return path.startsWith("/auth/login") || path.equals("/users") || path.equals("/auth/refresh") || path.startsWith("/auth/info");
+        return path.startsWith("/auth/login") || path.equals("/users") || path.equals("/auth/refresh") || path.startsWith("/auth/info")
+            || path.startsWith("/auth/dormant");
     }
 
 }

--- a/src/main/java/com/nhnacademy/yes25/infrastructure/adaptor/DoorayAdaptor.java
+++ b/src/main/java/com/nhnacademy/yes25/infrastructure/adaptor/DoorayAdaptor.java
@@ -1,0 +1,14 @@
+package com.nhnacademy.yes25.infrastructure.adaptor;
+
+import com.nhnacademy.yes25.application.service.dto.request.DoorayMessagePayload;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "doorayAdaptor", url = "${api.dooray}")
+public interface DoorayAdaptor {
+
+    @PostMapping
+    void sendAuthNumber(@RequestBody DoorayMessagePayload payload);
+}

--- a/src/main/java/com/nhnacademy/yes25/infrastructure/adaptor/UserAdaptor.java
+++ b/src/main/java/com/nhnacademy/yes25/infrastructure/adaptor/UserAdaptor.java
@@ -1,9 +1,11 @@
 package com.nhnacademy.yes25.infrastructure.adaptor;
 
+import com.nhnacademy.yes25.application.service.dto.request.UnlockDormantRequest;
 import com.nhnacademy.yes25.presentation.dto.request.LoginUserRequest;
 import com.nhnacademy.yes25.presentation.dto.response.LoginUserResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "userAdaptor", url = "${api.book-user}")
@@ -12,4 +14,6 @@ public interface UserAdaptor {
     @PostMapping("/users")
     LoginUserResponse findLoginUserByEmailAndPassword(@RequestBody LoginUserRequest loginUserRequest);
 
+    @PutMapping("/users/dormant")
+    void unLockDormantState(@RequestBody UnlockDormantRequest unlockDormantRequest);
 }

--- a/src/main/java/com/nhnacademy/yes25/presentation/controller/DormantController.java
+++ b/src/main/java/com/nhnacademy/yes25/presentation/controller/DormantController.java
@@ -1,0 +1,32 @@
+package com.nhnacademy.yes25.presentation.controller;
+
+import com.nhnacademy.yes25.application.service.DormantService;
+import com.nhnacademy.yes25.presentation.dto.request.CreateAuthNumberRequest;
+import com.nhnacademy.yes25.presentation.dto.request.SubmitAuthNumberRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class DormantController {
+
+    private final DormantService dormantService;
+
+    @PostMapping("/dormant")
+    public ResponseEntity<Void> createAuthNumber(@RequestBody CreateAuthNumberRequest request) {
+        dormantService.createAuthNumberByEmail(request);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/dormant/validate")
+    public ResponseEntity<Boolean> submitAuthNumber(@RequestBody SubmitAuthNumberRequest request) {
+        return ResponseEntity.ok(dormantService.updateUserStateByAuthNumber(request));
+    }
+}

--- a/src/main/java/com/nhnacademy/yes25/presentation/dto/request/CreateAuthNumberRequest.java
+++ b/src/main/java/com/nhnacademy/yes25/presentation/dto/request/CreateAuthNumberRequest.java
@@ -1,0 +1,5 @@
+package com.nhnacademy.yes25.presentation.dto.request;
+
+public record CreateAuthNumberRequest(String email) {
+
+}

--- a/src/main/java/com/nhnacademy/yes25/presentation/dto/request/SubmitAuthNumberRequest.java
+++ b/src/main/java/com/nhnacademy/yes25/presentation/dto/request/SubmitAuthNumberRequest.java
@@ -1,0 +1,5 @@
+package com.nhnacademy.yes25.presentation.dto.request;
+
+public record SubmitAuthNumberRequest(String email, String verificationCode) {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,10 +19,25 @@ spring:
     name: authority-server
   profiles:
     active: dev
+  data:
+    redis:
+      host: 133.186.241.167
+      port: 6379
+      database: 16
+      password: "*N2vya7H@muDTwdNMR!"
+
 jwt:
   access-token:
     expiration-ms: 3000000 # 2분 = 120,000ms
   refresh-token:
     expiration-ms: 86400000 # 24시간 = 86,400,000ms
   secret: ${JWT_SECRET}
+api:
+  dooray: https://hook.dooray.com/services/3204376758577275363/3824312399885046720/ZqH6q36TRc6JoU4aGrKTNA
 
+redisson:
+  config: |
+    singleServerConfig:
+      address: "redis://133.186.241.167:6379"
+      password: "*N2vya7H@muDTwdNMR!"
+      database: 16

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,6 +10,7 @@ eureka:
 
 api:
   book-user: http://localhost:8061
+  dooray: https://hook.dooray.com/services/3204376758577275363/3824312399885046720/ZqH6q36TRc6JoU4aGrKTNA
 
 logging:
   file:
@@ -46,6 +47,12 @@ spring:
   sql:
     init:
       mode: always
+  data:
+    redis:
+      host: 133.186.241.167
+      port: 6379
+      database: 16
+      password: "*N2vya7H@muDTwdNMR!"
 
 server:
   port: 8050


### PR DESCRIPTION
## 연관 이슈
이슈 번호 :

## 해당 PR은 어떤 유형의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Rename
- [ ] Test
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 휴면 유저의 인증번호를 관리하는 redis 추가 및 인증 번호가 일치하면 휴면 해제하는 기능 구현하였습니다.
- 로그인 시, 휴면인지 아닌지 확인합니다.
- 인증번호 발급 요청 시, 랜덤한 5자리 숫자를 생성합니다. 
- `key = 유저 이메일, value = 랜덤 5자리 숫자`가 redis에 3분동안 저장됩니다.
- 인증번호가 제출되면 `redis`의 저장된 값을 비교하여 일치하면 도서-회원 서버로 휴면 해제 요청이 전송됩니다.


## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [x] Yes
- [ ] No


## 결과
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->


### 인증번호 요청
<img width="513" alt="image" src="https://github.com/nhnacademy-be6-yes-25-5/yes-25-5-front-server/assets/105257665/8adffd4e-56bb-41fa-9593-b82b33bdc375">